### PR TITLE
finished uppercasing removal

### DIFF
--- a/SpaceAndTimeSDK.js
+++ b/SpaceAndTimeSDK.js
@@ -595,7 +595,7 @@ export default class SpaceAndTimeSDK {
             let accessToken = tokens.accessToken;
             let payload = {
                 biscuits: biscuitTokens,
-                sqlText: sqlText.toUpperCase(),
+                sqlText: sqlText
             }
         
             let accessTokenValue = 'Bearer ' + accessToken; 
@@ -632,7 +632,7 @@ export default class SpaceAndTimeSDK {
             let payload = {
                 biscuits: biscuitTokens,
                 resourceId: resourceId.toUpperCase(),
-                sqlText: sqlText.toUpperCase(),
+                sqlText: sqlText
             }
 
             let accessTokenValue = 'Bearer ' + accessToken; 
@@ -672,7 +672,7 @@ export default class SpaceAndTimeSDK {
                 payload = {
                     biscuits: biscuitTokens,
                     resourceId: resourceId.toUpperCase(),
-                    sqlText: sqlText.toUpperCase(),
+                    sqlText: sqlText,
                     rowCount: rowCount
                 }
             }
@@ -680,7 +680,7 @@ export default class SpaceAndTimeSDK {
                 payload = {
                 biscuits: biscuitTokens,
                 resourceId: resourceId.toUpperCase(),
-                sqlText: sqlText.toUpperCase()
+                sqlText: sqlText
                }
             }
 

--- a/examples.js
+++ b/examples.js
@@ -171,7 +171,7 @@ let accessType = "public_append";
 
 let createSchemaSQLText = "CREATE SCHEMA ETH";
 let createSqlText = "CREATE TABLE ETH.TESTETH12 (ID INT PRIMARY KEY, TEST VARCHAR)";
-let alterSqlText = "ALTER TABLE ETH.TESTETH12 ADD BLOCK_NUMBER BIGINT";
+let dropSqlText = "DROP TABLE ETH.TESTETH12";
 let insertSqlText = "INSERT INTO ETH.TESTETH12 VALUES(4, 'x4')"
 let selectSqlStatement = "SELECT * FROM ETH.TESTETH12"
 
@@ -190,8 +190,8 @@ console.log(createSchemaResponse, createSchemaError);
 let [CreateTableResponse, CreateTableError] = await initSDK.CreateTable(createSqlText, accessType, mainPublicKey, biscuitToken, biscuitArray);
 console.log(CreateTableResponse, CreateTableError);
 
-// Can be used to Alter and Drop
-let [DDLresponse, DDLerror] = await initSDK.DDL(resourceId, alterSqlText, biscuitToken, biscuitArray);
+// Can be used to Drop
+let [DDLresponse, DDLerror] = await initSDK.DDL(resourceId, dropSqlText, biscuitToken, biscuitArray);
 console.log(DDLresponse, DDLerror);
 
 // DML


### PR DESCRIPTION
Removed the conversion of the SQL queries written by the user to upper case.
Previously this led to the conversion of the User's data in ``DML``  to get converted to upper casing.

I'm letting the conversion stay in ``CreateSchema`` and the ``CREATE TABLE MY_NAMESPACE.MY_TABLE( id  int, name  varchar, PRIMARY KEY (id))`` part of the Table creation function though as it is required.